### PR TITLE
Fix for reports that don't load when haunt doesn't land due to target becoming invalid (dying, etc)

### DIFF
--- a/src/app/report/models/cast-stats.ts
+++ b/src/app/report/models/cast-stats.ts
@@ -403,7 +403,7 @@ export class CastStats {
       }
     }
 
-    if (this.addNeverFadeStats(cast)) {
+    if (this.addNeverFadeStats(cast) && cast.instances.length > 0) {
       this._neverFadeStats.castCount++;
       if (this._neverFadeStats.firstTimeStamp == undefined) {
         this._neverFadeStats.firstTimeStamp = cast.instances[0].timestamp;


### PR DESCRIPTION
very small fix that allows reports to load when a haunt doesn't land

example of reports where haunt doesn't land:

https://chauva.github.io/warlock/report/8Nbrhw6JB3dzAFQ7/Antigauze/3 (haunt doesnt land as Sarth dies)
https://chauva.github.io/warlock/report/TrLZV2kKnpRv6Xz7/Ystrasa/12 (haunt doesn't land on friendly target)